### PR TITLE
Prevent creation of stale branches in s3-sync cronjob

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,13 +1,8 @@
 name: S3-synchronization-cronjob
 
-# on:
-#   schedule:
-#     - cron: '0 8 * * *' # Run every 8am
-
 on:
-  push:
-    branches:
-      - prevent-creation-of-stale-branches
+  schedule:
+    - cron: '0 8 * * *' # Run every 8am
 
 env:
   SYNC_BRANCH_NAME: 's3-sync-branch-91rf9321'
@@ -47,7 +42,7 @@ jobs:
         with:
           node-version: '18.x'
       - run: npm install
-      # - run: npm run sync-script
+      - run: npm run sync-script
       - name: commit and push new file
         run: |
           git config --global user.name "S3 Synchronization Cronjob"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: S3-synchronization-cronjob
 
 on:
   schedule:
-    - cron: '0 8 * * *' # Everyday at 8am
+    - cron: '0 8 * * *'
 
 jobs:
   sync:
@@ -12,21 +12,21 @@ jobs:
         with:
           ref: master
           token: ${{ secrets.GH_TOKEN }}
-      - name: Generate random number
-        id: random
-        run: echo "::set-output name=value::$(echo $RANDOM)"
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      - name: Create branch
+      - name: Delete old sync branch if it exists
+        run: |
+          git push -d origin ${{ secrets.SYNCH_BRANCH_NAME }} &>/dev/null || true
+      - name: Create sync branch
         uses: peterjgrainger/action-create-branch@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
-          branch: sync-${{ steps.random.outputs.value }}
+          branch: ${{ secrets.SYNCH_BRANCH_NAME }}
       - uses: actions/checkout@v4
         with:
-          ref: sync-${{ steps.random.outputs.value }}
+          ref: ${{ secrets.SYNCH_BRANCH_NAME }}
           token: ${{ secrets.GH_TOKEN }}
       - name: create env file
         run: |
@@ -49,6 +49,7 @@ jobs:
           git push
       - name: create pull request
         run: |
-          gh pr create -B master -H sync-${{ steps.random.outputs.value }} --title 'Cronjob/Sync docs folder with s3' --body 'Created by Github action'
+          gh pr create -B master -H ${{ secrets.SYNCH_BRANCH_NAME }} --title 'Cronjob/Sync docs folder with s3' --body 'Created by Github action'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,8 +1,16 @@
 name: S3-synchronization-cronjob
 
+# on:
+#   schedule:
+#     - cron: '0 8 * * *' # Run every 8am
+
 on:
-  schedule:
-    - cron: '0 8 * * *'
+  push:
+    branches:
+      - prevent-creation-of-stale-branches
+
+env:
+  SYNC_BRANCH_NAME: 's3-sync-branch-91rf9321'
 
 jobs:
   sync:
@@ -17,16 +25,16 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Delete old sync branch if it exists
         run: |
-          git push -d origin ${{ secrets.SYNCH_BRANCH_NAME }} &>/dev/null || true
+          git push -d origin ${{ env.SYNC_BRANCH_NAME }} &>/dev/null || true
       - name: Create sync branch
         uses: peterjgrainger/action-create-branch@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
-          branch: ${{ secrets.SYNCH_BRANCH_NAME }}
+          branch: ${{ env.SYNC_BRANCH_NAME }}
       - uses: actions/checkout@v4
         with:
-          ref: ${{ secrets.SYNCH_BRANCH_NAME }}
+          ref: ${{ env.SYNC_BRANCH_NAME }}
           token: ${{ secrets.GH_TOKEN }}
       - name: create env file
         run: |
@@ -39,7 +47,7 @@ jobs:
         with:
           node-version: '18.x'
       - run: npm install
-      - run: npm run sync-script
+      # - run: npm run sync-script
       - name: commit and push new file
         run: |
           git config --global user.name "S3 Synchronization Cronjob"
@@ -49,7 +57,7 @@ jobs:
           git push
       - name: create pull request
         run: |
-          gh pr create -B master -H ${{ secrets.SYNCH_BRANCH_NAME }} --title 'Cronjob/Sync docs folder with s3' --body 'Created by Github action'
+          gh pr create -B master -H ${{ env.SYNC_BRANCH_NAME }} --title 'Cronjob/Sync docs folder with s3' --body 'Created by Github action'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
Current sync cronjob will create infinite stale branches for every synchronization PR. But with this change, it will only create one PR and use up the same one branch every day. 